### PR TITLE
Fix parse input

### DIFF
--- a/oecophylla/cli/launch.py
+++ b/oecophylla/cli/launch.py
@@ -203,7 +203,6 @@ def workflow(targets, input_dir, sample_sheet, params, envs,
              profile, output_dir, snakemake_args, local_cores, jobs,
              force, just_config, test):
     import snakemake
-    from skbio.io.registry import sniff
 
     # SNAKEMAKE
     snakefile = '%s/../../Snakefile' % os.path.abspath(os.path.dirname(__file__))
@@ -223,14 +222,6 @@ def workflow(targets, input_dir, sample_sheet, params, envs,
     elif (os.path.exists(params) and
           os.path.exists(envs) and
           os.path.exists(input_dir)):
-        # INPUT DIR
-        for inp_file in glob.glob('%s/*' % input_dir):
-
-            file_format = sniff(inp_file)[0]
-
-            if (file_format != 'fasta') and (file_format != 'fastq'):
-                raise TypeError('Input files need to be in FASTA'
-                                ' or FASTQ format.')
 
         # OUTPUT
         # create output directory, if does not exist

--- a/oecophylla/util/parse.py
+++ b/oecophylla/util/parse.py
@@ -212,9 +212,10 @@ def extract_samples_from_sample_sheet(sample_sheet_df, seq_dir,
         f_fps = sorted(f_fps)
         r_fps = sorted(r_fps)
 
-        sample_reads_dict[s] = {
-            'forward': [os.path.join(seq_dir, x) for x in f_fps],
-            'reverse': [os.path.join(seq_dir, x) for x in r_fps]
-        }
+        if f_fps != [] and r_fps != []:
+          sample_reads_dict[s] = {
+              'forward': [os.path.join(seq_dir, x) for x in f_fps],
+              'reverse': [os.path.join(seq_dir, x) for x in r_fps]
+          }
 
     return(sample_reads_dict)

--- a/oecophylla/util/tests/test_parse.py
+++ b/oecophylla/util/tests/test_parse.py
@@ -185,5 +185,38 @@ class TestParse(unittest.TestCase):
         self.assertDictEqual(sample_paths, exp_sample_paths)
 
 
+    def test_extract_samples_from_sample_sheet_missing(self):
+        seq_dir = '%s/../../../test_data/test_reads' % os.path.abspath(
+            os.path.dirname(__file__))
+        ss_df = pd.DataFrame(
+            [[1, 'S22205', 'S22205', 'Example Plate 1', 'A1',
+              'iTru7_101_01', 'ACGTTACC', 'iTru5_01_A', 'ACCGACAA',
+              'Example Project',  'sample_S22205'],
+             [1, 'S22282', 'S22282', 'Example Plate 1', 'B1',
+              'iTru7_101_02', 'CTGTGTTG', 'iTru5_01_B', 'AGTGGCAA',
+              'Example Project','sample_S22282'],
+             [1, 'not_here', 'not_here', 'Example Plate 1', 'B1',
+              'iTru7_101_02', 'CTGTGTTG', 'iTru5_01_B', 'AGTGGCAA',
+              'Example Project','sample_not_here']],
+            columns=['Lane', 'Sample_ID', 'Sample_Name', 'Sample_Plate',
+                   'Sample_Well', 'I7_Index_ID', 'index', 'I5_Index_ID',
+                   'index2', 'Sample_Project', 'Description'])
+
+        sample_paths = extract_samples_from_sample_sheet(
+            ss_df, seq_dir, name_col='Description', prefix_col='Sample_ID')
+
+        exp_sample_paths = {
+            'sample_S22282': {
+                'forward': ['%s/S22282_S102_L001_R1_001.fastq.gz' % seq_dir],
+                'reverse': ['%s/S22282_S102_L001_R2_001.fastq.gz' % seq_dir]},
+            'sample_S22205': {
+                'forward': ['%s/S22205_S104_L001_R1_001.fastq.gz' % seq_dir],
+                'reverse': ['%s/S22205_S104_L001_R2_001.fastq.gz' % seq_dir]
+            }
+        }
+        self.assertDictEqual(sample_paths, exp_sample_paths)
+
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes a bug in parsing input directories where *every* file in input directory needs to be a fastq. 

Redundant because only filenames conforming to illumina demux formats will be parsed anyway. 