### PR TITLE
Added local execution for raw_combine_files

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -38,6 +38,9 @@ include: "oecophylla/taxonomy/taxonomy.rule"
 include: "oecophylla/function/function.rule"
 # include: "oecophylla/report/report.rule"
 
+# execute the basic filesystem read combine locally, not as submitted job
+localrules: raw_combine_files
+
 rule all:
     input:
         # raw


### PR DESCRIPTION
This just changes the initial fastq combine rule to happen on the local node. It's nicer to the cluster because: 1. will restrict the number of simultaneous writes to the filesystem to whatever you pass to `--local-cores` and 2: doesn't hammer the scheduler with tiny jobs