### PR TITLE
Cleanup log names

### DIFF
--- a/oecophylla/anvio/anvio.rule
+++ b/oecophylla/anvio/anvio.rule
@@ -10,9 +10,9 @@ rule anvi_gen_contigs_database:
     threads:
         4
     log:
-        anvio_dir + "logs/anvi_gen_contigs_database.sample=[{bin_sample}].log"
+        anvio_dir + "logs/anvi_gen_contigs_database.sample_{bin_sample}.log"
     benchmark:
-        "benchmarks/anvio/anvi_gen_contigs_database.sample=[{bin_sample}].txt"
+        "benchmarks/anvio/anvi_gen_contigs_database.sample_{bin_sample}.txt"
     run:
         with tempfile.TemporaryDirectory(dir=find_local_scratch(TMP_DIR_ROOT)) as temp_dir:
             dbname = os.path.basename(output.db)
@@ -34,9 +34,9 @@ rule anvi_run_hmms:
     threads:
         12
     log:
-        anvio_dir + "logs/anvi_run_hmms.sample=[{bin_sample}].log"
+        anvio_dir + "logs/anvi_run_hmms.sample_{bin_sample}.log"
     benchmark:
-        "benchmarks/anvio/anvi_run_hmms.sample=[{bin_sample}].txt"
+        "benchmarks/anvio/anvi_run_hmms.sample_{bin_sample}.txt"
     run:
         db = os.path.join(os.path.dirname(input[0]),wildcards.bin_sample + '.db')
         shell("""
@@ -52,9 +52,9 @@ rule anvi_export_gene_calls:
     output:
         anvio_dir + "{bin_sample}/{bin_sample}.gene-calls.fa"
     log:
-        anvio_dir + "logs/anvi_export_gene_calls.sample=[{bin_sample}].log"
+        anvio_dir + "logs/anvi_export_gene_calls.sample_{bin_sample}.log"
     benchmark:
-        "benchmarks/anvio/anvi_export_gene_calls.sample=[{bin_sample}].txt"
+        "benchmarks/anvio/anvi_export_gene_calls.sample_{bin_sample}.txt"
     run:
         with tempfile.TemporaryDirectory(dir=find_local_scratch(TMP_DIR_ROOT)) as temp_dir:
             out_name = os.path.basename(output[0])
@@ -76,9 +76,9 @@ rule anvi_run_centrifuge:
         report=anvio_dir + "{bin_sample}/centrifuge_report.tsv",
         done=touch(anvio_dir + "{bin_sample}/{bin_sample}.db.added_centrifuge.done")
     log:
-        anvio_dir + "logs/anvi_run_centrifuge.sample=[{bin_sample}].log"
+        anvio_dir + "logs/anvi_run_centrifuge.sample_{bin_sample}.log"
     benchmark:
-        "benchmarks/anvio/anvi_run_centrifuge.sample=[{bin_sample}].txt"
+        "benchmarks/anvio/anvi_run_centrifuge.sample_{bin_sample}.txt"
     params:
         centrifuge_base=config['params']['anvio']['centrifuge_base'],
         centrifuge_models=config['params']['anvio']['centrifuge_models']
@@ -121,9 +121,9 @@ rule anvi_profile:
         prof=anvio_dir + "{bin_sample}/{bin_sample}.{abund_sample}.bam-ANVIO_PROFILE/PROFILE.db",
         log=anvio_dir + "{bin_sample}/{bin_sample}.{abund_sample}.bam-ANVIO_PROFILE/RUNLOG.txt"
     log:
-        anvio_dir + "logs/anvi_profile.sample=[{bin_sample}].abund_sample=[{abund_sample}].log"
+        anvio_dir + "logs/anvi_profile.sample_{bin_sample}.abund_sample_{abund_sample}.log"
     benchmark:
-        "benchmarks/anvio/anvi_profile.sample=[{bin_sample}].abund_sample=[{abund_sample}].txt"
+        "benchmarks/anvio/anvi_profile.sample_{bin_sample}.abund_sample_{abund_sample}.txt"
     threads: 12
     run:
         with tempfile.TemporaryDirectory(dir=find_local_scratch(TMP_DIR_ROOT)) as temp_dir:
@@ -160,9 +160,9 @@ rule anvi_merge:
         runlog=anvio_dir + "{bin_sample}/SAMPLES_MERGED/RUNLOG.txt",
         samps=anvio_dir + "{bin_sample}/SAMPLES_MERGED/SAMPLES.db"
     log:
-        anvio_dir + "logs/anvi_merge.sample=[{bin_sample}].log"
+        anvio_dir + "logs/anvi_merge.sample_{bin_sample}.log"
     benchmark:
-        "benchmarks/anvio/anvi_merge.sample=[{bin_sample}].txt"
+        "benchmarks/anvio/anvi_merge.sample_{bin_sample}.txt"
     run:
         with tempfile.TemporaryDirectory(dir=find_local_scratch(TMP_DIR_ROOT)) as temp_dir:
             merge_dir = os.path.dirname(output.prof)
@@ -186,9 +186,9 @@ rule anvi_add_maxbin:
     output:
         touch(anvio_dir + "{bin_sample}/{bin_sample}.db.anvi_add_maxbin.done")
     log:
-        anvio_dir + "logs/anvi_add_maxbin.sample=[{bin_sample}].log"
+        anvio_dir + "logs/anvi_add_maxbin.sample_{bin_sample}.log"
     benchmark:
-        "benchmarks/anvio/anvi_add_maxbin.sample=[{bin_sample}].txt"
+        "benchmarks/anvio/anvi_add_maxbin.sample_{bin_sample}.txt"
     run:
         db = os.path.join(os.path.dirname(input.db_done),wildcards.bin_sample + '.db')
         shell("""
@@ -211,9 +211,9 @@ rule anvi_summarize:
         report = anvio_dir + "{bin_sample}/{bin_sample}_samples-summary_CONCOCT.html",
         txt = anvio_dir + "{bin_sample}/{bin_sample}_samples-summary_CONCOCT.txt"
     log:
-        anvio_dir + "logs/anvi_summarize.sample=[{bin_sample}].log"
+        anvio_dir + "logs/anvi_summarize.sample_{bin_sample}.log"
     benchmark:
-        "benchmarks/anvio/anvi_summarize.sample=[{bin_sample}].txt"
+        "benchmarks/anvio/anvi_summarize.sample_{bin_sample}.txt"
     run:
         with tempfile.TemporaryDirectory(dir=find_local_scratch(TMP_DIR_ROOT)) as temp_dir:
             db = os.path.join(os.path.dirname(input.db_done),wildcards.bin_sample + '.db')

--- a/oecophylla/assemble/assemble.rule
+++ b/oecophylla/assemble/assemble.rule
@@ -13,9 +13,9 @@ rule assemble_megahit:
     threads:
         12
     log:
-        assemble_dir + "logs/assemble_megahit.sample=[{sample}].log"
+        assemble_dir + "logs/assemble_megahit.sample_{sample}.log"
     benchmark:
-        "benchmarks/assemble/assemble_megahit.sample=[{sample}].txt"
+        "benchmarks/assemble/assemble_megahit.sample_{sample}.txt"
     run:
         with tempfile.TemporaryDirectory(dir=find_local_scratch(TMP_DIR_ROOT)) as temp_dir:
             mem_b = params.memory * 1000000000
@@ -41,9 +41,9 @@ rule assemble_metaspades:
     output:
         assemble_dir + "{sample}/metaspades/{sample}.contigs.fa"
     log:
-        assemble_dir + "logs/assemble_metaspades.sample=[{sample}].log"
+        assemble_dir + "logs/assemble_metaspades.sample_{sample}.log"
     benchmark:
-        "benchmarks/assemble/assemble_metaspades.sample=[{sample}].txt"
+        "benchmarks/assemble/assemble_metaspades.sample_{sample}.txt"
     params:
         mem=240,
         env = config['envs']['assemble']
@@ -73,9 +73,9 @@ rule assemble_spades:
     output:
         assemble_dir + "{sample}/spades/{sample}.contigs.fa"
     log:
-        assemble_dir + "logs/assemble_spades.sample=[{sample}].log"
+        assemble_dir + "logs/assemble_spades.sample_{sample}.log"
     benchmark:
-        "benchmarks/assemble/assemble_spades.sample=[{sample}].txt"
+        "benchmarks/assemble/assemble_spades.sample_{sample}.txt"
     params:
         mem=240,
         env = config['envs']['assemble']
@@ -106,11 +106,11 @@ rule assemble_metaquast:
     output:
         done = assemble_dir + "{sample}/metaquast/{sample}.metaquast.done"
     log:
-        assemble_dir + "logs/assemble_metaquast.sample=[{sample}].log"
+        assemble_dir + "logs/assemble_metaquast.sample_{sample}.log"
     threads:
         12
     benchmark:
-        "benchmarks/assemble/assemble_metaquast.sample=[{sample}].txt"
+        "benchmarks/assemble/assemble_metaquast.sample_{sample}.txt"
     params:
         env = config['envs']['assemble']
     run:
@@ -137,11 +137,11 @@ rule assemble_quast:
     output:
         done = assemble_dir + "{sample}/quast/{sample}.quast.done"
     log:
-        assemble_dir + "logs/assemble_quast.sample=[{sample}].log"
+        assemble_dir + "logs/assemble_quast.sample_{sample}.log"
     threads:
         8
     benchmark:
-        "benchmarks/assemble/assemble_quast.sample=[{sample}].txt"
+        "benchmarks/assemble/assemble_quast.sample_{sample}.txt"
     params:
         env = config['envs']['assemble']
     run:
@@ -167,7 +167,7 @@ rule assemble_simplify_fasta_headers:
         fasta = assemble_dir + "{sample}/{assembler}/{sample}.contigs.simple.fa",
         headers = assemble_dir + "{sample}/{assembler}/{sample}.contigs.headers.txt"
     log:
-        assemble_dir + "logs/assemble_simplify_fasta_headers.sample=[{sample}].log"
+        assemble_dir + "logs/assemble_simplify_fasta_headers.sample_{sample}.log"
     threads:
         1
     run:

--- a/oecophylla/bin/bin.rule
+++ b/oecophylla/bin/bin.rule
@@ -7,9 +7,9 @@ rule bin_make_cov_files:
     output:
         temp(bin_dir + "{bin_sample}/abundance_files/{bin_sample}_abund_list.txt")
     log:
-        bin_dir + "logs/bin_make_cov_files.sample=[{bin_sample}].log"
+        bin_dir + "logs/bin_make_cov_files.sample_{bin_sample}.log"
     benchmark:
-        "benchmarks/bin/bin_make_cov_files.sample=[{bin_sample}].txt"
+        "benchmarks/bin/bin_make_cov_files.sample_{bin_sample}.txt"
     threads:
         12
     run:
@@ -41,9 +41,9 @@ rule bin_run_maxbin:
     output: 
         bin_dir + "{bin_sample}/maxbin/{bin_sample}.summary"
     log:
-        bin_dir + "logs/bin_run_maxbin.sample=[{bin_sample}].log"
+        bin_dir + "logs/bin_run_maxbin.sample_{bin_sample}.log"
     benchmark:
-        "benchmarks/bin/bin_run_maxbin.sample=[{bin_sample}].txt"
+        "benchmarks/bin/bin_run_maxbin.sample_{bin_sample}.txt"
     params:
         maxbin = config['params']['maxbin']
     threads:
@@ -67,9 +67,9 @@ rule summarize_maxbin:
     output:
         bin_dir + "{bin_sample}/maxbin/{bin_sample}_maxbin_bins.txt"
     log:
-        bin_dir + "logs/summarize_maxbin.sample=[{bin_sample}].log"
+        bin_dir + "logs/summarize_maxbin.sample_{bin_sample}.log"
     benchmark:
-        "benchmarks/bin/summarize_maxbin.sample=[{bin_sample}].txt"
+        "benchmarks/bin/summarize_maxbin.sample_{bin_sample}.txt"
     threads:
         1
     run:
@@ -96,7 +96,7 @@ rule tar_bin_cov_files:
     threads:
         1
     benchmark:
-        "benchmarks/bin/tar_bin_cov_files.sample=[{bin_sample}].txt"
+        "benchmarks/bin/tar_bin_cov_files.sample_{bin_sample}.txt"
     run:
         abund_dir = os.path.dirname(input.abund_list)
         with tempfile.TemporaryDirectory(dir=find_local_scratch(TMP_DIR_ROOT)) as temp_dir:

--- a/oecophylla/distance/distance.rule
+++ b/oecophylla/distance/distance.rule
@@ -14,9 +14,9 @@ rule mash_sketch:
     threads:
         1
     log:
-        distance_dir + "logs/mash_sketch.sample=[{sample}].log"
+        distance_dir + "logs/mash_sketch.sample_{sample}.log"
     benchmark:
-        "benchmarks/distance/mash_sketch.sample=[{sample}].txt"
+        "benchmarks/distance/mash_sketch.sample_{sample}.txt"
     run:
         output_base = os.path.splitext(output[0])[0]
 
@@ -117,9 +117,9 @@ rule sourmash_sig:
     threads:
         1
     log:
-        distance_dir + "logs/sourmash_sig.sample=[{sample}].log"
+        distance_dir + "logs/sourmash_sig.sample_{sample}.log"
     benchmark:
-        "benchmarks/distance/sourmash_sig.sample=[{sample}].txt"
+        "benchmarks/distance/sourmash_sig.sample_{sample}.txt"
     run:
         with tempfile.TemporaryDirectory(dir=TMP_DIR_ROOT) as temp_dir:
             shell("""

--- a/oecophylla/function/function.rule
+++ b/oecophylla/function/function.rule
@@ -60,9 +60,9 @@ rule function_humann2:
     threads:
         8
     log:
-        func_dir + "logs/function_humann2_{sample}.log"
+        func_dir + "logs/function_humann2.sample_{sample}.log"
     benchmark:
-        "benchmarks/function/function_humann2_{sample}.json"
+        "benchmarks/function/function_humann2.sample_{sample}.json"
     run:
         with tempfile.TemporaryDirectory(dir=TMP_DIR_ROOT) as temp_dir:
             shell("""
@@ -231,9 +231,9 @@ rule function_shogun:
     threads:
         8
     log:
-        func_dir + "logs/function_shogun_{sample}.log"
+        func_dir + "logs/function_shogun.sample_{sample}.log"
     benchmark:
-        "benchmarks/function/function_shogun_{sample}.json"
+        "benchmarks/function/function_shogun.sample_{sample}.json"
     run:
         out_dir = os.path.dirname(output[0])
         # out_dir = os.path.join(func_dir, "{sample}/shogun")

--- a/oecophylla/map/map.rule
+++ b/oecophylla/map/map.rule
@@ -4,9 +4,9 @@ rule map_bowtie2_index:
     output:
         touch(map_dir + "{bin_sample}/mapping/{bin_sample}.done")
     log:
-        map_dir + "logs/map_bowtie2_index.sample=[{bin_sample}].log"
+        map_dir + "logs/map_bowtie2_index.sample_{bin_sample}.log"
     benchmark:
-        "benchmarks/map/map_bowtie2_index.sample=[{bin_sample}].txt"
+        "benchmarks/map/map_bowtie2_index.sample_{bin_sample}.txt"
     threads:
         12
     run:
@@ -23,10 +23,10 @@ rule map_bowtie2:
         bam = temp(map_dir + "{bin_sample}/mapping/{bin_sample}_{abund_sample}.bam"),
         bai = temp(map_dir + "{bin_sample}/mapping/{bin_sample}_{abund_sample}.bam.bai")
     log:
-        bowtie = map_dir + "logs/map_bowtie2.sample=[{bin_sample}].abund_sample=[{abund_sample}].bowtie.log",
-        other = map_dir + "logs/map_bowtie2.sample=[{bin_sample}].abund_sample=[{abund_sample}].other.log"
+        bowtie = map_dir + "logs/map_bowtie2.sample_{bin_sample}.abund_sample_{abund_sample}.bowtie.log",
+        other = map_dir + "logs/map_bowtie2.sample_{bin_sample}.abund_sample_{abund_sample}.other.log"
     benchmark:
-        "benchmarks/map/map_bowtie2.sample=[{bin_sample}].abund_sample=[{abund_sample}].txt"
+        "benchmarks/map/map_bowtie2.sample_{bin_sample}.abund_sample_{abund_sample}.txt"
     threads:
         12
     run:
@@ -51,9 +51,9 @@ rule map_faidx_index:
     output:
         assemble_dir + "{bin_sample}/%s/{bin_sample}.contigs.simple.fa.fai" % config['params']['mapping_assembler']
     log:
-        map_dir + "logs/map_faidx_index.sample=[{bin_sample}].log"
+        map_dir + "logs/map_faidx_index.sample_{bin_sample}.log"
     benchmark:
-        "benchmarks/map/map_faidx_index.sample=[{bin_sample}].txt"
+        "benchmarks/map/map_faidx_index.sample_{bin_sample}.txt"
     threads:
         1
     run:
@@ -70,9 +70,9 @@ rule map_cram:
     params:
         cram = config['params']['cram']
     log:
-        map_dir + "logs/map_cram.sample=[{bin_sample}].abund_sample=[{abund_sample}].log"
+        map_dir + "logs/map_cram.sample_{bin_sample}.abund_sample_{abund_sample}.log"
     benchmark:
-        "benchmarks/map/map_cram.sample=[{bin_sample}].abund_sample=[{abund_sample}].txt"
+        "benchmarks/map/map_cram.sample_{bin_sample}.abund_sample_{abund_sample}.txt"
     threads:
         12
     run:

--- a/oecophylla/qc/qc.rule
+++ b/oecophylla/qc/qc.rule
@@ -10,7 +10,7 @@ rule raw_per_file_fastqc:
     threads:
         4
     log:
-        raw_dir + "logs/raw_per_file_fastqc.sample=[{sample}].log"
+        raw_dir + "logs/raw_per_file_fastqc.sample_{sample}.log"
     params:
         env = config['envs']['raw']
     run:
@@ -61,7 +61,7 @@ rule raw_combine_files:
     threads:
         4
     log:
-        raw_dir + "logs/raw_combine_files.sample=[{sample}].log"
+        raw_dir + "logs/raw_combine_files.sample_{sample}.log"
     run:
         f_fastqs = ' '.join(input.forward)
         r_fastqs = ' '.join(input.reverse)
@@ -86,7 +86,7 @@ rule raw_per_sample_fastqc:
     params:
         env = config['envs']['raw']
     log:
-        raw_dir + "logs/raw_per_sample_fastqc.sample=[{sample}].log"
+        raw_dir + "logs/raw_per_sample_fastqc.sample_{sample}.log"
     run:
         out_dir = os.path.dirname(output[0])
         print(out_dir)
@@ -145,9 +145,9 @@ rule qc_atropos:
         atropos = config['params']['atropos'],
         env = config['envs']['qc']
     log:
-        qc_dir + "logs/qc_atropos.sample=[{sample}].log"
+        qc_dir + "logs/qc_atropos.sample_{sample}.log"
     benchmark:
-        "benchmarks/qc/qc_atropos.sample=[{sample}].txt"
+        "benchmarks/qc/qc_atropos.sample_{sample}.txt"
     run:
         with tempfile.TemporaryDirectory(dir=find_local_scratch(TMP_DIR_ROOT)) as temp_dir:
             f_fp = os.path.basename(output.forward)
@@ -191,10 +191,10 @@ rule qc_filter:
     threads:
         4
     log:
-        bowtie = qc_dir + "logs/qc_filter.bowtie.sample=[{sample}].log",
-        other = qc_dir + "logs/qc_filter.other.sample=[{sample}].log"
+        bowtie = qc_dir + "logs/qc_filter.bowtie.sample_{sample}.log",
+        other = qc_dir + "logs/qc_filter.other.sample_{sample}.log"
     benchmark:
-         "benchmarks/qc/qc_filter.sample=[{sample}].txt"
+         "benchmarks/qc/qc_filter.sample_{sample}.txt"
     run:
         if params.filter_db is None:
             f_fp = os.path.abspath(input.forward)
@@ -242,9 +242,9 @@ rule qc_per_sample_fastqc:
     params:
         env = config['envs']['qc']
     log:
-        qc_dir + "logs/qc_per_sample_fastqc.sample=[{sample}].log"
+        qc_dir + "logs/qc_per_sample_fastqc.sample_{sample}.log"
     benchmark:
-        "benchmarks/qc/qc_per_sample_fastqc.sample=[{sample}].txt"
+        "benchmarks/qc/qc_per_sample_fastqc.sample_{sample}.txt"
     run:
         out_dir = os.path.dirname(output[0])
         shell("""

--- a/oecophylla/report/report.rule
+++ b/oecophylla/report/report.rule
@@ -58,7 +58,7 @@ def load_multiqc_data(fp, label_col=None, label_val=None, column_prefix=None,
 
 
 # function to read a benchmark file
-def read_benchmark(fp, pattern = '^.*benchmarks/(.+?)/(.+?)\.sample=\[(.+?)\](\.abund_sample=\[(.+?)\])?\.txt$'):
+def read_benchmark(fp, pattern = '^.*benchmarks/(.+?)/(.+?)\.sample_(.+?)(\.abund_sample_(.+?))?\.txt$'):
     # check to make sure .txt filepath matches expected format
     m = re.search(pattern, fp)
 

--- a/oecophylla/taxonomy/taxonomy.rule
+++ b/oecophylla/taxonomy/taxonomy.rule
@@ -29,9 +29,9 @@ rule taxonomy_metaphlan2:
     threads:
         2
     log:
-        taxonomy_dir + "logs/taxonomy_metaphlan2.{sample}.log"
+        taxonomy_dir + "logs/taxonomy_metaphlan2.sample_{sample}.log"
     benchmark:
-        "benchmarks/taxonomy/taxonomy_metaphlan2.{sample}.txt"
+        "benchmarks/taxonomy/taxonomy_metaphlan2.sample_{sample}.txt"
     run:
         with tempfile.TemporaryDirectory(dir=find_local_scratch(TMP_DIR_ROOT)) as temp_dir:
             shell("""
@@ -124,9 +124,9 @@ rule taxonomy_kraken:
     threads:
         12
     log:
-        taxonomy_dir + "logs/taxonomy_kraken.sample=[{sample}].log"
+        taxonomy_dir + "logs/taxonomy_kraken.sample_{sample}.log"
     benchmark:
-        "benchmarks/taxonomy/taxonomy_kraken.sample=[{sample}].txt"
+        "benchmarks/taxonomy/taxonomy_kraken.sample_{sample}.txt"
     run:
         with tempfile.TemporaryDirectory(dir=find_local_scratch(TMP_DIR_ROOT)) as temp_dir:
             shell("""
@@ -238,9 +238,9 @@ rule taxonomy_centrifuge:
     threads:
         12
     log:
-        taxonomy_dir + "logs/taxonomy_centrifuge.sample=[{sample}].log"
+        taxonomy_dir + "logs/taxonomy_centrifuge.sample_{sample}.log"
     benchmark:
-        "benchmarks/taxonomy/taxonomy_centrifuge.sample=[{sample}].txt"
+        "benchmarks/taxonomy/taxonomy_centrifuge.sample_{sample}.txt"
     run:
         with tempfile.TemporaryDirectory(dir=find_local_scratch(TMP_DIR_ROOT)) as temp_dir:
             shell("""
@@ -328,9 +328,9 @@ rule taxonomy_shogun:
     threads:
         12
     log:
-        taxonomy_dir + "logs/taxonomy_shogun.sample=[{sample}].log"
+        taxonomy_dir + "logs/taxonomy_shogun.sample_{sample}.log"
     benchmark:
-        "benchmarks/taxonomy/taxonomy_shogun.sample=[{sample}].txt"
+        "benchmarks/taxonomy/taxonomy_shogun.sample_{sample}.txt"
     run:
         aln2ext = {'utree': 'tsv', 'burst': 'b6', 'bowtie2': 'sam'}
         ext = aln2ext[params['aligner']]


### PR DESCRIPTION
log and benchmark filenames with structures like:

`raw_qc.sample=[{sample}].log` 

were causing problems because the `[=` characters don't play nicely with bash wildcards. 

cleaned up and standardized to look like:

`raw_qc.sample_{sample}.log`