### PR TITLE
updated temp dir specifications in a few rules

### DIFF
--- a/oecophylla/distance/distance.rule
+++ b/oecophylla/distance/distance.rule
@@ -121,7 +121,7 @@ rule sourmash_sig:
     benchmark:
         "benchmarks/distance/sourmash_sig.sample_{sample}.txt"
     run:
-        with tempfile.TemporaryDirectory(dir=TMP_DIR_ROOT) as temp_dir:
+        with tempfile.TemporaryDirectory(dir=find_local_scratch(TMP_DIR_ROOT)) as temp_dir:
             shell("""
                   set +u; {params.env}; set -u
                   zcat {input.forward} {input.reverse} > {temp_dir}/{wildcards.sample}

--- a/oecophylla/function/function.rule
+++ b/oecophylla/function/function.rule
@@ -64,7 +64,7 @@ rule function_humann2:
     benchmark:
         "benchmarks/function/function_humann2.sample_{sample}.json"
     run:
-        with tempfile.TemporaryDirectory(dir=TMP_DIR_ROOT) as temp_dir:
+        with tempfile.TemporaryDirectory(dir=find_local_scratch(TMP_DIR_ROOT)) as temp_dir:
             shell("""
                   set +u; {params.env}; set -u
 
@@ -123,7 +123,7 @@ rule function_humann2_combine_tables:
         "benchmarks/function/function_humann2_combine_tables.json"
     run:
         out_dir = os.path.join(func_dir, "humann2")
-        with tempfile.TemporaryDirectory(dir=TMP_DIR_ROOT) as temp_dir:
+        with tempfile.TemporaryDirectory(dir=find_local_scratch(TMP_DIR_ROOT)) as temp_dir:
             shell("""
                   set +u; {params.env}; set -u
 


### PR DESCRIPTION
There were a few rules that just called `TMP_DIR_ROOT` directly without interpreting shell variables. This causes problems when using more complex scratch specifications, as on Comet, or in the new `/panfs/panfs1.ucsd.edu/panscratch/$USER` scratch specification on Barnacle.