### PR TITLE
updated humann2 install with explicit glpk version

### DIFF
--- a/oecophylla/function/oecophylla-humann2.yaml
+++ b/oecophylla/function/oecophylla-humann2.yaml
@@ -2,6 +2,8 @@ channels:
   - bioconda
   - anaconda
   - biocore
+  - conda-forge
 dependencies:
+  - glpk==4.65
   - humann2
   - biom-format


### PR DESCRIPTION
Some samples were failing sporadically on some datasets, with errors coming from certain samples  that looked like:

```
CRITICAL ERROR: Unable to process all thread commands.
Error message returned from command for thread task 2: ...
```

This came from [a problem with the glpk version](https://groups.google.com/forum/#!topic/humann-users/MSVmXC7DSW0) being installed. 

Explicitly specifying in the conda version recipe resolves. 