### PR TITLE
Added catch to handle common file format

### DIFF
--- a/oecophylla/util/parse.py
+++ b/oecophylla/util/parse.py
@@ -140,7 +140,10 @@ def read_sample_sheet(f, sep=',', comment='#'):
                 if line.startswith('[') or line.strip() == '':
                     data = False
                     continue
-                data_lines += line
+                elif not line.startswith(sep):
+                    data_lines += line
+                else:
+                    continue
             elif line.startswith('[Data]'):
                 data = True
                 continue


### PR DESCRIPTION
Sample sheets appear to routinely include blank lines that are comprised solely of commas in between samples. To exclude these lines, I added a check to determine if the line starts with the sep character and if so, skip adding it to data_lines to prevent corruption of the dataframe in the next function.