### PR TITLE
Update oecophylla-centrifuge.yaml

### DIFF
--- a/oecophylla/taxonomy/oecophylla-centrifuge.yaml
+++ b/oecophylla/taxonomy/oecophylla-centrifuge.yaml
@@ -1,4 +1,4 @@
 channels:
   - bioconda
 dependencies:
-  - centrifuge=1.0.3=py36pl5.22.0_1
+  - centrifuge=1.0.3


### PR DESCRIPTION
Version spec was too specific and would cause issues when installing taxonomy. Fixes issue #154