### PR TITLE
Updating tool_params.yml

### DIFF
--- a/cluster_configs/barnacle/tool_params.yml
+++ b/cluster_configs/barnacle/tool_params.yml
@@ -18,7 +18,7 @@ humann2:
   other: ''
 maxbin: -plotmarker
 metaphlan2:
-  db: /databases/metaphlan2/db_v20/mpa_v20_m200
+  db: /databases/metaphlan2/db_v20/
   # taxon name to TaxID dictionary
   name2tid: 
   levels: phylum,genus,species


### PR DESCRIPTION
Not sure when/where the change occurred, but metaphlan2 consistently failed for me on barnacle, so I dug into the error logs and IDed that this change was needed to enable metaphlan2 to find the right db files